### PR TITLE
Quote object keys to be valid JSON

### DIFF
--- a/check_elasticquery_6x.pl
+++ b/check_elasticquery_6x.pl
@@ -291,7 +291,7 @@ if (defined $p->opts->search && not defined $p->opts->json) {
 		}
 
 		# Fetch filters from saved query
-		my $raw_bool_clauses = 'filter: [],';
+		my $raw_bool_clauses = '"filter": [],';
 		if (ref $meta->{filter} eq ref []) {
 			$raw_bool_clauses = getBooleanClauses($meta->{filter});
 		}

--- a/check_elasticquery_7x.pl
+++ b/check_elasticquery_7x.pl
@@ -319,7 +319,7 @@ if (defined $p->opts->search && not defined $p->opts->json) {
 		}
 
 		# Fetch filters from saved query
-		my $raw_bool_clauses = 'filter: [],';
+		my $raw_bool_clauses = '"filter": [],';
 		if (ref $meta->{filter} eq ref []) {
 			$raw_bool_clauses = getBooleanClauses($meta->{filter});
 		}


### PR DESCRIPTION
The tests were failing due to invalid JSON being returned. This commit
fixes the problem by adding quotes around one instance of the object key
`filter`.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>