### PR TITLE
Add tests for 7x

### DIFF
--- a/t/mock_api_7x.pl
+++ b/t/mock_api_7x.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+use Mojolicious::Lite;
+use Data::Dumper;
+use JSON;
+
+my %savedSearches;
+$savedSearches{"saved_search_1"}{"index_hash"}  = "d9922a60-449d-11e9-932a-bfe6cbee1330";
+$savedSearches{"saved_search_1"}{"index_name"}  = "bla";
+$savedSearches{"saved_search_1"}{"count"}        = 25;
+$savedSearches{"saved_search_1"}{"query"}       = "user_agent = Mozilla*";
+
+$savedSearches{"saved_search_2"}{"index_hash"}  = "d9922a60-449d-11e9-932a-bfe6cbee1331";
+$savedSearches{"saved_search_2"}{"index_name"}  = "bla";
+$savedSearches{"saved_search_2"}{"count"}        = 12;
+$savedSearches{"saved_search_2"}{"query"}       = "user_agent = Mozilla*";
+
+post '/.kibana/_search' => sub {
+    my ( $mojo ) = @_;
+    my $body = $mojo->req->body;
+    my $json = decode_json ($body);
+    my $searchTitle = $json->{'query'}->{'bool'}->{'must'}[0]->{'match'}->{"search.title"};
+    my $savedSearch = $savedSearches{"$searchTitle"};
+    return $mojo->render(
+        json =>
+            { hits => {hits => [{_source => {search => {kibanaSavedObjectMeta => {searchSourceJSON => '{"index":"' . $savedSearch->{'index_hash'} .'","query":{"query":"' . $savedSearch->{'query'} . '"}}'} }}},]}}
+    );
+};
+
+get "/.kibana/doc/index-pattern:hash" => sub {
+    my ( $mojo ) = @_;
+    my $hash = substr($mojo->stash('hash'),1);
+    my $savedSearch = findSearchByHash($hash);
+    return $mojo->render(
+        json => {_source => {'index-pattern' => {title => $savedSearch->{'index_name'}}}}
+    );
+};
+
+post '/:index_name/_count' => sub {
+    my ( $mojo ) = @_;
+    my $index_name = $mojo->stash('index_name');
+    my $body = $mojo->req->body;
+    my $json = decode_json ($body);
+    my $query = $json->{'query'}->{'bool'}->{'must'}[0]->{'query_string'}->{"query"};
+    my $savedSearch = findSearchByIndexQuery($index_name, $query);
+    return $mojo->render(
+        json => {count => $savedSearch->{'count'}}
+    );
+};
+
+sub findSearchByHash {
+    my ($hash) = @_;
+    keys %savedSearches; # reset the internal iterator so a prior each() doesn't affect the loop
+    while(my($k, $v) = each %savedSearches) {
+        if ($v->{"index_hash"} eq $hash) {
+            return $v;
+        }
+    }
+}
+
+sub findSearchByIndexQuery {
+    my ($index, $query) = @_;
+    keys %savedSearches; # reset the internal iterator so a prior each() doesn't affect the loop
+    while(my($k, $v) = each %savedSearches) {
+        if ($v->{"index_name"} eq $index && $v->{"query"} eq $query) {
+            return $v;
+        }
+    }
+}
+
+# app->secrets(['My very secret passphrase.']);
+app->start;

--- a/t/mock_test_7x.pl
+++ b/t/mock_test_7x.pl
@@ -1,0 +1,44 @@
+use Test::Simple tests => 7;
+use IPC::Open3;
+use Cwd 'abs_path';
+use File::Basename;
+
+my $dirname = dirname(abs_path($0));
+my $script = "$dirname/../check_elasticquery_7x.pl";
+
+# Setup of Mock API server
+print "Starting mock API server...\n";
+my($wtr, $rdr, $err);
+use Symbol 'gensym'; $err = gensym;
+$mockapi_pid = open3($wtr, $rdr, $err,
+                    "$dirname/mock_api_7x.pl", "daemon");
+sleep(2);
+
+my $output, $exitcode;
+
+# Test OK
+$output = `$script -U 'http://localhost:3000' -S 'saved_search_1' -T 'now:now-30d' -w 35 -c 50`;
+$exitcode = $?>>8;
+
+ok ($exitcode == 0);
+ok (index($output, "OK") != -1);
+
+# Test Warning
+$output = `$script -U 'http://localhost:3000' -S 'saved_search_2' -T 'now:now-30d' -w 20 -c 30`;
+$exitcode = $?>>8;
+
+ok ($exitcode == 1);
+ok (index($output, "WARNING") != -1);
+
+# Test critical
+$output = `$script -U 'http://localhost:3000' -S 'saved_search_2' -T 'now:now-30d' -w 10 -c 20`;
+$exitcode = $?>>8;
+
+ok ($exitcode == 2);
+ok (index($output, "CRITICAL") != -1);
+
+# verify perfdata format
+ok (index($output, "total=25;10;20") != -1);
+
+# shut down the mock API server
+kill 'TERM', $mockapi_pid;


### PR DESCRIPTION
This commit adds tests for check_elasticquery_7x.pl. The tests are
identical to what we already had for 6x, but are adapted to handle the
use of _count instead of _search in 7x.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>