### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Execute json query. Time range option wouldn't work. You should define time rang
 
 `./check_elasticquery_7x.pl -U 'http://user:password@localhost:9200' -i 'beats*' -j -q '
 {
- "size": 0,
  "query": {
     "bool": {
       "must": [


### PR DESCRIPTION
In 7x we use _count API so we can't use size in json query.